### PR TITLE
[FIX] Fix nested array isolation in Observer constructor

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,6 +1,6 @@
 import { Events } from './events';
 import { ObserverHistory } from './observer-history';
-import { arrayEquals } from './utils';
+import { arrayEquals, deepCopyArray } from './utils';
 
 /**
  * The ObserverSync class is used to construct an interface for synchronizing changes from Observer
@@ -202,7 +202,7 @@ class Observer extends Events {
             for (i = 0; i < target._data[key].length; i++) {
                 if (typeof target._data[key][i] === 'object' && target._data[key][i] !== null) {
                     if (target._data[key][i] instanceof Array) {
-                        target._data[key][i].slice(0);
+                        target._data[key][i] = deepCopyArray(target._data[key][i]);
                     } else {
                         target._data[key][i] = new Observer(target._data[key][i], {
                             parent: this,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,4 +38,27 @@ const arrayEquals = (a: any[], b: any[]) => {
     return true;
 };
 
-export { arrayEquals };
+/**
+ * Creates a deep copy of an array, recursively copying any nested arrays.
+ * Non-array objects within the array are not deep copied (they remain references).
+ *
+ * @param arr - The array to copy.
+ * @returns A deep copy of the array with all nested arrays also copied.
+ *
+ * @example
+ * const original = [[1, 2], [3, 4]];
+ * const copy = deepCopyArray(original);
+ * copy[0][0] = 99;
+ * console.log(original[0][0]); // 1 (unchanged)
+ */
+const deepCopyArray = (arr: any[]): any[] => {
+    const copy = arr.slice(0);
+    for (let i = 0; i < copy.length; i++) {
+        if (copy[i] instanceof Array) {
+            copy[i] = deepCopyArray(copy[i]);
+        }
+    }
+    return copy;
+};
+
+export { arrayEquals, deepCopyArray };


### PR DESCRIPTION
Fixes playcanvas/editor#684

### Overview

The Observer class was not properly isolating nested arrays from source data, causing issues when the source data was modified externally (e.g., by ShareDB during real-time collaboration).

### The Problem

When creating an Observer from data containing nested arrays (like `[[1,2,3], [4,5,6]]`), the inner arrays were not being copied - only the outer array was shallow copied. This meant the Observer and the source data shared references to the same inner arrays.

In the Editor, this caused script attributes with array types (e.g., `vec3[]`) to fail live-updating in the Launch tab:
1. User changes a vec3 array attribute in the Inspector
2. ShareDB receives the operation and updates its document data
3. Because the Observer shared the same inner array reference, its data was also modified
4. When `observer.set()` was called, the value was already the same, so no `*:set` event fired
5. The Launch tab never received the update

### The Fix

- Added `deepCopyArray()` utility function in `utils.ts` (alongside existing `arrayEquals`)
- Fixed line 205 in `_prepare()` which was calling `.slice(0)` but discarding the result:
  // Before (bug)
  target._data[key][i].slice(0);
  
  // After (fixed)
  target._data[key][i] = deepCopyArray(target._data[key][i]);
  
3 unit tests have been added. All fail without the fix but now pass.

The original Editor issue is confirmed fixed.